### PR TITLE
[Touch.Client] Silence numerous warnings about using native API too early, where it's not supported, or when obsoleted.

### DIFF
--- a/Touch.Client/dotnet/shared.csproj
+++ b/Touch.Client/dotnet/shared.csproj
@@ -3,6 +3,11 @@
     <DefineConstants>NUNITLITE_NUGET</DefineConstants>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Touch.Client</AssemblyName>
+
+    <!-- warning CA1416: This call site is reachable on: '...'. '...' is only supported on: '...'. -->
+    <NoWarn>$(NoWarn);CA1416</NoWarn>
+    <!-- warning CA1422: This call site is reachable on: '...'. '...' is obsoleted on: '...'. -->
+    <NoWarn>$(NoWarn);CA1422</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\..\NUnitLite\TouchRunner\ExcludedCategoryFilter.cs">


### PR DESCRIPTION
Everything currently works, and we're not spending much time on Touch.Client, so just silence any warnings we may have.